### PR TITLE
Initial write ahead log primitives.

### DIFF
--- a/Panda.Logging.UnitTests/ChecksumTests.cs
+++ b/Panda.Logging.UnitTests/ChecksumTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.InteropServices;
 using System.Text;
 using Xunit;
 

--- a/Panda.Logging.UnitTests/ChecksumTests.cs
+++ b/Panda.Logging.UnitTests/ChecksumTests.cs
@@ -45,7 +45,7 @@ public class ChecksumTests
     {
         IChecksumProvider sut = new Crc32CheckSumProvider();
         var inputBytes = Encoding.UTF8.GetBytes(inputString);
-        var result = sut.VerifyChecksum(inputBytes, checksum);
+        var result = sut.VerifyChecksum(checksum, inputBytes);
         Assert.Equal(expected, result);
     }
 

--- a/Panda.Logging.UnitTests/ChecksumTests.cs
+++ b/Panda.Logging.UnitTests/ChecksumTests.cs
@@ -56,4 +56,17 @@ public class ChecksumTests
 
         Assert.Throws<ArgumentNullException>("byteStream", () => sut.ComputeChecksum(null!));
     }
+
+    [Fact]
+    public void TwoArraysPassedInOrderProducesSameOutputAsSameDataInSingleArray()
+    {
+        var combinedTestCase = new byte[] { 1, 2, 3, 4 };
+        var separatedTestCase = new[] { new byte[] { 1, 2 }, new byte[] { 3, 4 } };
+        var sut = new Crc32CheckSumProvider();
+
+        var expected = sut.ComputeChecksum(combinedTestCase);
+        var actual = sut.ComputeChecksum(separatedTestCase[0], separatedTestCase[1]);
+
+        Assert.Equal(expected, actual);
+    }
 }

--- a/Panda.Logging.UnitTests/LogReaderWriterTests.cs
+++ b/Panda.Logging.UnitTests/LogReaderWriterTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+
+namespace Panda.Logging.UnitTests;
+
+public class LogReaderWriterTests
+{
+
+    private readonly IChecksumProvider _checksumProvider;
+    private readonly Mock<IChecksumProvider> _mockChecksumProvider;
+    public LogReaderWriterTests()
+    {
+        var checksumProviderMock = new Mock<IChecksumProvider>();
+        checksumProviderMock
+            .Setup(i => i.VerifyChecksum(It.IsAny<uint>(), It.IsAny<IEnumerable<byte>[]>()))
+            .Returns(true);
+
+        checksumProviderMock
+            .Setup(i => i.ComputeChecksum(It.IsAny<IEnumerable<byte>[]>()))
+            .Returns(0u);
+        _checksumProvider = checksumProviderMock.Object;
+        _mockChecksumProvider = checksumProviderMock;
+    }
+    [Fact]
+    public async Task LogWriterBasicVerificationTests()
+    {
+        var logWriter = new LogWriter(_checksumProvider);
+        // Because we are writing no data, we expect this record to be 20 bytes.
+        const int expectedLength = 8 + 8 + 4;
+        const byte expectedByte = 0; // We expect all bytes to be 0, because we have a 0 serial number, 0 length, and 0 checksum (see constructor)
+        await using var memoryStream = new MemoryStream();
+        await logWriter.WriteAsync(memoryStream, new LogEntry(0, Array.Empty<byte>()), CancellationToken.None);
+        var bytes = memoryStream.ToArray();
+
+        Assert.Equal(expectedLength, bytes.Length);
+        Assert.All(bytes, b => Assert.Equal(expectedByte, b));
+    }
+
+    [Theory]
+    [MemberData(nameof(LogEntries))]
+    public async Task LogReaderCanDecodeOutputOfLogWriter(LogEntry sourceLogEntry)
+    {
+        var logWriter = new LogWriter(_checksumProvider);
+        var logReader = new LogReader(_checksumProvider);
+
+        await using var memoryStream = new MemoryStream();
+        await logWriter.WriteAsync(memoryStream, sourceLogEntry, CancellationToken.None);
+        await memoryStream.FlushAsync(CancellationToken.None);
+        memoryStream.Seek(0, SeekOrigin.Begin);
+        var logEntry = await logReader.ReadAsync(memoryStream, true, CancellationToken.None);
+
+        Assert.NotNull(logEntry);
+        Assert.Equal(sourceLogEntry.SerialNumber, logEntry.SerialNumber);
+        Assert.Equal(sourceLogEntry.Data, logEntry.Data);
+    }
+
+    public static IEnumerable<object[]> LogEntries()
+    {
+        yield return new object[] { new LogEntry(1, Array.Empty<byte>()) };
+        var largeData = new byte[16384 * 4];
+        yield return new object[] { new LogEntry(long.MinValue, largeData) };
+    }
+}

--- a/Panda.Logging.UnitTests/Panda.Logging.UnitTests.csproj
+++ b/Panda.Logging.UnitTests/Panda.Logging.UnitTests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Panda.Logging/ByteArrayExtensions.cs
+++ b/Panda.Logging/ByteArrayExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace Panda.Logging;
+
+public static class ByteArrayExtensions
+{
+    public static byte[] EnsureLittleEndian(this byte[] bytes)
+    {
+        if (BitConverter.IsLittleEndian) return bytes;
+        return bytes.Reverse().ToArray();
+    }
+}

--- a/Panda.Logging/Crc32CheckSumProvider.cs
+++ b/Panda.Logging/Crc32CheckSumProvider.cs
@@ -24,11 +24,25 @@ public class Crc32CheckSumProvider : IChecksumProvider
         }).ToArray();
     }
 
-    public uint ComputeChecksum(IEnumerable<byte> byteStream)
+    public uint ComputeChecksum(params IEnumerable<byte>[] byteStream)
     {
         if (byteStream == null) throw new ArgumentNullException(nameof(byteStream));
         // Initialize checksumRegister to 0xFFFFFFFF and calculate the checksum.
-        return ~byteStream.Aggregate(0xFFFFFFFF, (checksumRegister, currentByte) =>
-            (_checksumTable[(checksumRegister & 0xFF) ^ Convert.ToByte(currentByte)] ^ (checksumRegister >> 8)));
+        var register = 0xFFFFFFFF;
+        for (var x = 0; x < byteStream.Length; x++)
+        {
+            register = ComputePartialChecksum(register, byteStream[x]);
+        }
+        return ~register;
+    }
+
+    private uint ComputePartialChecksum(uint register, IEnumerable<byte> bytes)
+    {
+        foreach (var b in bytes)
+        {
+            register = (_checksumTable[(register & 0xFF) ^ b] ^ (register >> 8));
+        }
+
+        return register;
     }
 }

--- a/Panda.Logging/IChecksumProvider.cs
+++ b/Panda.Logging/IChecksumProvider.cs
@@ -2,6 +2,6 @@
 
 public interface IChecksumProvider
 {
-    uint ComputeChecksum(IEnumerable<byte> bytes);
-    bool VerifyChecksum(IEnumerable<byte> bytes, uint checkSum) => ComputeChecksum(bytes) == checkSum;
+    uint ComputeChecksum(params IEnumerable<byte>[] bytes);
+    bool VerifyChecksum(uint checkSum, params IEnumerable<byte>[] bytes) => ComputeChecksum(bytes) == checkSum;
 }

--- a/Panda.Logging/ILogReader.cs
+++ b/Panda.Logging/ILogReader.cs
@@ -1,0 +1,8 @@
+﻿namespace Panda.Logging;
+
+public interface ILogReader
+{
+    Task<LogEntry> ReadAsync(Stream reader, CancellationToken cancellationToken) =>
+        ReadAsync(reader, validateChecksum: true, cancellationToken);
+    Task<LogEntry> ReadAsync(Stream reader, bool validateChecksum, CancellationToken cancellationToken);
+}

--- a/Panda.Logging/ILogWriter.cs
+++ b/Panda.Logging/ILogWriter.cs
@@ -1,0 +1,6 @@
+﻿namespace Panda.Logging;
+
+public interface ILogWriter
+{
+    Task WriteAsync(Stream writer, LogEntry logEntry, CancellationToken cancellationToken);
+}

--- a/Panda.Logging/LogEntry.cs
+++ b/Panda.Logging/LogEntry.cs
@@ -1,0 +1,3 @@
+﻿namespace Panda.Logging;
+
+public record LogEntry(long SerialNumber, byte[] Data);

--- a/Panda.Logging/LogReader.cs
+++ b/Panda.Logging/LogReader.cs
@@ -1,0 +1,71 @@
+﻿using System.Buffers;
+
+namespace Panda.Logging;
+
+public class LogReader : ILogReader
+{
+    private readonly IChecksumProvider _checksumProvider;
+
+    public LogReader(IChecksumProvider checksumProvider)
+    {
+        _checksumProvider = checksumProvider;
+    }
+
+    public async Task<LogEntry> ReadAsync(Stream reader, bool validateChecksum, CancellationToken cancellationToken)
+    {
+        const int SequenceByteLength = 8;
+        const int LengthByteLength = 8;
+        const int ChecksumByteLength = 4;
+        const int BufferSize = 16384;
+        // This function will be used _a lot_
+        // So, let's avoid any non-stack allocations we can where possible.
+        // ArrayPool will allow us to share these buffers and never free them.
+        // but we can't use it for the actual data bytes, and we MUST make sure they
+        // get returned at the end of the function.
+        var sequenceBytes = ArrayPool<byte>.Shared.Rent(SequenceByteLength);
+        var lengthBytes = ArrayPool<byte>.Shared.Rent(LengthByteLength);
+        var checksumBytes = ArrayPool<byte>.Shared.Rent(ChecksumByteLength);
+        var readBuffer = ArrayPool<byte>.Shared.Rent(BufferSize);
+        try
+        {
+            await reader.ReadAsync(sequenceBytes, 0, SequenceByteLength, cancellationToken);
+            await reader.ReadAsync(lengthBytes, 0, LengthByteLength, cancellationToken);
+            var dataByteLength = BitConverter.ToInt64(lengthBytes.EnsureLittleEndian(), 0);
+            var dataBytes = new byte[dataByteLength];
+            int currentOffset = 0;
+
+            while (dataByteLength > 0)
+            {
+                var bytesToRead = dataByteLength > readBuffer.Length ? readBuffer.Length : (int)dataByteLength;
+                var bytesRead = await reader.ReadAsync(readBuffer, 0, bytesToRead, cancellationToken);
+                if (bytesRead == 0) throw new EndOfStreamException("The log stream ended unexpectedly.");
+                Array.Copy(readBuffer, 0, dataBytes, currentOffset, bytesRead);
+                currentOffset += bytesRead;
+                dataByteLength -= bytesRead;
+
+            }
+
+            await reader.ReadAsync(checksumBytes, 0, ChecksumByteLength, cancellationToken);
+
+            if (validateChecksum)
+            {
+                var checksum = BitConverter.ToUInt32(checksumBytes.EnsureLittleEndian());
+                if (!_checksumProvider.VerifyChecksum(checksum, sequenceBytes.EnsureLittleEndian(), lengthBytes.EnsureLittleEndian(), dataBytes))
+                {
+                    throw new InvalidDataException("Checksum in stream does not match computed checksum.");
+                }
+            }
+
+            var serialNumber = BitConverter.ToInt64(sequenceBytes.EnsureLittleEndian());
+            
+            return new LogEntry(serialNumber, dataBytes);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(sequenceBytes);
+            ArrayPool<byte>.Shared.Return(lengthBytes);
+            ArrayPool<byte>.Shared.Return(readBuffer);
+            ArrayPool<byte>.Shared.Return(checksumBytes);
+        }
+    }
+}

--- a/Panda.Logging/LogWriter.cs
+++ b/Panda.Logging/LogWriter.cs
@@ -1,0 +1,26 @@
+﻿namespace Panda.Logging;
+
+public class LogWriter : ILogWriter
+{
+    private readonly IChecksumProvider _checksumProvider;
+
+    public LogWriter(IChecksumProvider checksumProvider)
+    {
+        _checksumProvider = checksumProvider;
+    }
+
+    public async Task WriteAsync(Stream writer, LogEntry logEntry, CancellationToken cancellationToken)
+    {
+        var serialNumberBytes = BitConverter.GetBytes(logEntry.SerialNumber).EnsureLittleEndian();
+        var dataLengthBytes = BitConverter.GetBytes(logEntry.Data.LongLength).EnsureLittleEndian();
+        // This does mean we loop over the data twice, but we do avoid copying all of it to a new buffer
+        // to compute the checksum.
+        var checksum = _checksumProvider.ComputeChecksum(serialNumberBytes, dataLengthBytes, logEntry.Data);
+        await writer.WriteAsync(serialNumberBytes, cancellationToken);
+        await writer.WriteAsync(dataLengthBytes, cancellationToken);
+
+        if (logEntry.Data.LongLength > 0)
+            await writer.WriteAsync(logEntry.Data, cancellationToken);
+        await writer.WriteAsync(BitConverter.GetBytes(checksum).EnsureLittleEndian(), cancellationToken);
+    }
+}


### PR DESCRIPTION
This is the initial primitive implementation for the write ahead log.
This provides only basic wire/file format and serialization/deserialization.
This is only a building block for a more complicated log structure.

Closes #11 